### PR TITLE
create .nojekyll to bypass Jekyll processing on Github Pages

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -55,3 +55,6 @@ docs/_build/
 
 # PyBuilder
 target/
+
+#MacOS
+.DS_Store


### PR DESCRIPTION
Directories starting with underscores are ignored by default which breaks static files in Sphinx. GitHub’s preprocessor can be disabled to support Sphinx HTML output properly by creating a file named .nojekyll in the root of your pages repo and pushing it to GitHub
